### PR TITLE
Testing/details page cont

### DIFF
--- a/cypress/fixtures/movie-incomplete.json
+++ b/cypress/fixtures/movie-incomplete.json
@@ -2,8 +2,8 @@
   "movie": {
     "id": 737173,
     "title": "Maratón After",
-    "poster_path": "https://image.tmdb.org/t/p/original//f4aul3FyD3jv3v4bul1IrkWZvzq.jpg",
-    "backdrop_path": "https://image.tmdb.org/t/p/original//xFxk4vnirOtUxpOEWgA1MCRfy6J.jpg",
+    "poster_path": null,
+    "backdrop_path": "",
     "release_date": null,
     "overview": "",
     "genres": [],

--- a/cypress/fixtures/movie-no-title.json
+++ b/cypress/fixtures/movie-no-title.json
@@ -1,0 +1,22 @@
+{
+  "movie": {
+    "id": 508439,
+    "title": null,
+    "poster_path": "https://image.tmdb.org/t/p/original//f4aul3FyD3jv3v4bul1IrkWZvzq.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//xFxk4vnirOtUxpOEWgA1MCRfy6J.jpg",
+    "release_date": "2020-02-29",
+    "overview": "In a suburban fantasy world, two teenage elf brothers embark on an extraordinary quest to discover if there is still a little magic left out there.",
+    "genres": [
+    "Animation",
+    "Family",
+    "Adventure",
+    "Comedy",
+    "Fantasy"
+    ],
+    "budget": 200000000,
+    "revenue": 103181419,
+    "runtime": 102,
+    "tagline": "Their quest begineth.",
+    "average_rating": 6.4
+  }
+}

--- a/cypress/integration/errorHandling_spec.js
+++ b/cypress/integration/errorHandling_spec.js
@@ -1,4 +1,4 @@
-describe('Error modal on landing page', () => {
+describe('Errors on landing page', () => {
 
   it('should handle 500 errors', () => {
     cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
@@ -22,7 +22,7 @@ describe('Error modal on landing page', () => {
     cy.get('.error-modal > p')
       .should('include.text','404')
       .should('include.text','Please reload the page and try again!')
-  })
+  });
 
   it('should not show a movie card if data is missing', () => {
     cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies', { fixture: 'movies-incomplete.json'})
@@ -32,30 +32,65 @@ describe('Error modal on landing page', () => {
     cy.get('.all-movies')
       .children('.card-container')
       .should('have.length', 3)
-  })
+  });
+});
 
-  it.only('should handle missing data for single movie', () => {
+describe('Error handling for missing movie details', () => {
+  it('should replace any missing movie details (other than title)', () => {
     cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies/*', { fixture: 'movie-incomplete.json'})
-
     cy.visit('http://localhost:3000')
       .get('.card').first().click()
-    // 
-    // cy.get('.movie-tagline')
-    //   .should('not.exist')
 
+    cy.get('.movie-tagline')
+      .should('have.text', '')
+
+    cy.get('.runtime')
+      .should('have.text', 'unavailable')
+
+    cy.get('.rating')
+      .should('have.text', 'unavailable')
+
+    cy.get('.side-img')
+      .should('have.attr', 'src', 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg')
+
+    cy.get('.backdrop-img')
+      .should('have.attr', 'src', 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg')
+
+    cy.get('.genre')
+      .should('have.text', 'Genre: unavailable')
+
+    cy.get('.release-date')
+      .should('have.text', 'Release Date: unavailable')
+
+    cy.get('.budget')
+      .should('have.text', 'Budget: unavailable')
+
+    cy.get('.revenue')
+      .should('have.text', 'Revenue: unavailable')
+
+    cy.get('.movie-overview')
+      .should('have.text', 'description unavailable')
+  });
+});
+
+describe('Error handling for for single movie page', () => {
+  it('should show the error modal if a movie is missing a title', () => {
+    cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies/*', { fixture: 'movie-no-title.json' })
+    cy.visit('http://localhost:3000')
+      .get('.card').first().click()
+
+    cy.get('.error-modal > p')
+      .should('include.text','Oh no! Looks like this was a rancid tomatillo.')
+      .get('a')
+      .should('include.text', 'Take me to the Rotten Tomatillos home page')
+  });
+
+  it('should show a 404 error if a url is entered with a movie id that doesnt exist', () => {
+    cy.visit('http://localhost:3000/90000000')
+
+    cy.get('.error-modal > p')
+      .should('include.text','404')
+      .get('a')
+      .should('include.text', 'Take me to the Rotten Tomatillos home page')
   })
-  // "poster_path": null,
-  // "backdrop_path": null,
-  // "release_date": null,
-  // "overview": "",
-  // "genres": [],
-  // "budget": 0,
-  // "revenue": 0,
-  // "runtime": 0,
-  // "tagline": "",
-  // "average_rating": null
-
-  it('should show an error if movie is missing title', () => {
-
-  })
-})
+});

--- a/cypress/integration/errorHandling_spec.js
+++ b/cypress/integration/errorHandling_spec.js
@@ -9,7 +9,7 @@ describe('Errors on landing page', () => {
 
     cy.get('.error-modal > p')
       .should('include.text','500')
-      .should('include.text','Please reload the page and try again!')
+      .should('include.text','We\'re having some trouble loading the page. Please try again later!')
   })
 
   it('should handle 404 errors', () => {
@@ -21,7 +21,23 @@ describe('Errors on landing page', () => {
 
     cy.get('.error-modal > p')
       .should('include.text','404')
-      .should('include.text','Please reload the page and try again!')
+      .should('include.text','Oh no! Looks like this was a rancid tomatillo.')
+      .get('a')
+      .should('include.text', 'Take me to the Rotten Tomatillos home page')
+  });
+
+  it('should handle 400 errors', () => {
+    cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 401
+    })
+
+    cy.visit('http://localhost:3000')
+
+    cy.get('.error-modal > p')
+      .should('include.text','401')
+      .should('include.text','Oops! Something went wrong. Please reload the page and try agian.')
+      .get('a')
+      .should('include.text', 'Take me to the Rotten Tomatillos home page')
   });
 
   it('should not show a movie card if data is missing', () => {

--- a/cypress/integration/landingPage_spec.js
+++ b/cypress/integration/landingPage_spec.js
@@ -1,24 +1,16 @@
-describe('rancid tomatillos landing page', () => {
-
-  beforeEach(() => {
+describe('Rancid Tomatillos landing page', () => {
+  it('should show a landing page with a nav bar, title, and a card for each movie with that movies details', () => {
     cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies', { fixture: 'movies.json'})
-
     cy.visit('http://localhost:3000');
-  })
 
-  it('should have title in nav bar', () => {
     cy.get('nav')
       .find('h1')
       .should('have.text', 'Rancid Tomatillos')
-  })
 
-  it('should have a container with 16 movie cards', () => {
     cy.get('.all-movies')
       .find('.card-container')
       .should('have.length', 16)
-  })
 
-  it('should have a movie card for each movie with an image, title and rating', () => {
     cy.get('.card-container:first')
       .find('.title')
       .should('have.text', 'Money Plane')
@@ -30,5 +22,5 @@ describe('rancid tomatillos landing page', () => {
     cy.get('.card-container:first')
       .find('.card-image')
       .should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg')
-  })
-})
+  });
+});

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -60,7 +60,13 @@ const api = {
     return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/${path}`)
       .then(response => {
         if (!response.ok) {
-          throw (`${response.status} ${response.statusText}. Please reload the page and try again!`);
+          if (response.status >= 500) {
+            throw (`${response.status} ${response.statusText}. We're having some trouble loading the page. Please try again later!`);
+          } else if (response.status === 404){
+            throw (`${response.status} ${response.statusText}. Oh no! Looks like this was a rancid tomatillo.`);
+          } else {
+            throw (`${response.status} ${response.statusText}. Oops! Something went wrong. Please reload the page and try agian.`);
+          }
         }
         return response.json()
       })

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -11,34 +11,37 @@ const formatNumber = (num) => {
 
 const cleanData = (movie) => {
   let keys = Object.keys(movie);
-
+  
   keys.forEach(key => {
-    if (!movie[key] && movie[key] === movie.overview) {
-      movie[key] = 'description unavailable'
-    } else if (movie[key] === movie.budget && !movie.budget){
-      movie.budget =  'not available'
-    } else if (movie[key] === movie.revenue && !movie.revenue){
-      movie.revenue =  'not available'
-    } else if (movie[key] === movie.budget || movie[key] === movie.revenue) {
-      movie[key] = `$ ${formatNumber(movie[key])}`
-    } else if (movie[key] === movie.runtime) {
-      movie[key] = `${movie[key]} minutes`
-    } else if (movie[key] === movie.genres && movie.genres.length === 0) {
-      movie.genres.push('not available')
-    } else if (movie[key] === movie.release_date && !movie.release_date){
+    if (key === "overview" && !movie[key]) {
+      movie[key] = 'description unavailable';
+    } else if (key === "budget" && !movie.budget) {
+      movie.budget =  'not available';
+    } else if (key === "revenue" && !movie.revenue) {
+      movie.revenue =  'not available';
+    } else if (key === "budget" || key === "revenue") {
+      movie[key] = `$ ${formatNumber(movie[key])}`;
+    } else if (key === "runtime" && movie[key]) {
+      movie[key] = `${movie[key]} minutes`;
+    } else if (key === "runtime" && !movie[key]) {
+      movie[key] = 'unavailable';
+    } else if (key === "genres" && movie.genres.length === 0) {
+      movie.genres.push('not available');
+    } else if (key === "release_date" && !movie.release_date) {
       movie.release_date = 'not available';
-    } else if (movie[key] === movie.release_date && movie.release_date){
+    } else if (key === "release_date" && movie.release_date) {
       movie.release_date = formatDate(movie.release_date);
-    } else if (movie[key] === movie.average_rating && movie.average_rating){
+    } else if (key === "average_rating" && movie.average_rating) {
       movie.average_rating = movie.average_rating.toFixed(1);
-    } else if (movie[key] === movie.average_rating && !movie.average_rating){
+    } else if (key === "average_rating" && !movie.average_rating) {
       movie.average_rating = 'not available';
-    } else if (movie[key] === movie.poster_path && !movie.poster_path){
-      movie.poster_path = 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg';
-    } else if (movie[key] === movie.backdrop_path && !movie.backdrop_path){
+    } else if (key === "poster_path" && !movie.poster_path) {
+      movie.poster_path = "https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg";
+    } else if (key === "backdrop_path" && !movie.backdrop_path) {
       movie.backdrop_path = 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg';
     }
   });
+
   movie.genres = movie.genres.join(', ');
   return movie;
 }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,40 +4,40 @@ const formatDate = (date) => {
 }
 
 const formatNumber = (num) => {
-    var string = num.toString().split(".");
-    string[0] = string[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    return string.join(".");
+    var string = num.toString().split('.');
+    string[0] = string[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return string.join('.');
 }
 
 const cleanData = (movie) => {
   let keys = Object.keys(movie);
-  
+
   keys.forEach(key => {
-    if (key === "overview" && !movie[key]) {
+    if (key === 'overview' && !movie[key]) {
       movie[key] = 'description unavailable';
-    } else if (key === "budget" && !movie.budget) {
-      movie.budget =  'not available';
-    } else if (key === "revenue" && !movie.revenue) {
-      movie.revenue =  'not available';
-    } else if (key === "budget" || key === "revenue") {
+    } else if (key === 'budget' && !movie.budget) {
+      movie.budget =  'unavailable';
+    } else if (key === 'revenue' && !movie.revenue) {
+      movie.revenue =  'unavailable';
+    } else if (key === 'budget' || key === 'revenue') {
       movie[key] = `$ ${formatNumber(movie[key])}`;
-    } else if (key === "runtime" && movie[key]) {
+    } else if (key === 'runtime' && movie[key]) {
       movie[key] = `${movie[key]} minutes`;
-    } else if (key === "runtime" && !movie[key]) {
+    } else if (key === 'runtime' && !movie[key]) {
       movie[key] = 'unavailable';
-    } else if (key === "genres" && movie.genres.length === 0) {
-      movie.genres.push('not available');
-    } else if (key === "release_date" && !movie.release_date) {
-      movie.release_date = 'not available';
-    } else if (key === "release_date" && movie.release_date) {
+    } else if (key === 'genres' && movie.genres.length === 0) {
+      movie.genres.push('unavailable');
+    } else if (key === 'release_date' && !movie.release_date) {
+      movie.release_date = 'unavailable';
+    } else if (key === 'release_date' && movie.release_date) {
       movie.release_date = formatDate(movie.release_date);
-    } else if (key === "average_rating" && movie.average_rating) {
+    } else if (key === 'average_rating' && movie.average_rating) {
       movie.average_rating = movie.average_rating.toFixed(1);
-    } else if (key === "average_rating" && !movie.average_rating) {
-      movie.average_rating = 'not available';
-    } else if (key === "poster_path" && !movie.poster_path) {
-      movie.poster_path = "https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg";
-    } else if (key === "backdrop_path" && !movie.backdrop_path) {
+    } else if (key === 'average_rating' && !movie.average_rating) {
+      movie.average_rating = 'unavailable';
+    } else if (key === 'poster_path' && !movie.poster_path) {
+      movie.poster_path = 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg';
+    } else if (key === 'backdrop_path' && !movie.backdrop_path) {
       movie.backdrop_path = 'https://www.esm.rochester.edu/uploads/NoPhotoAvailable.jpg';
     }
   });
@@ -53,7 +53,6 @@ const cleanAllData = (movies) => {
     }
   })
 }
-
 
 const api = {
 

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -7,7 +7,7 @@ const ErrorModal = ({error}) => {
     <div className='error-modal'>
       <p className='modal-content'>
         {error}
-        <Link to='/'>Take me to the Rotten Tomatillos home page</Link>
+        {!error.includes('500') && <Link to='/'>Take me to the Rotten Tomatillos home page</Link>}
       </p>
     </div>
   )

--- a/src/components/SingleMovie/SingleMovie.js
+++ b/src/components/SingleMovie/SingleMovie.js
@@ -51,12 +51,12 @@ class SingleMovie extends Component {
           <div className='header-details'>
             <div className='runtime-container'>
               <p className='bold-text'>Runtime:</p>
-              <p>{movie.runtime}</p>
+              <p className='runtime'>{movie.runtime}</p>
             </div>
             <div className='rating-container'>
               <p className='bold-text'>Rating:</p>
               <img className='sm-logo' src={tomatillo} alt='tomitillo'/>
-              <p>{movie.average_rating}</p>
+              <p className='rating'>{movie.average_rating}</p>
             </div>
           </div>
           </header>
@@ -66,10 +66,10 @@ class SingleMovie extends Component {
           </div>
           <div className='details-row'>
             <div className='movie-details'>
-              <p><span className='bold-text'>Genre:</span> {movie.genres}</p>
-              <p><span className='bold-text'>Release Date:</span> {movie.release_date}</p>
-              <p><span className='bold-text'>Budget:</span> {movie.budget}</p>
-              <p><span className='bold-text'>Revenue:</span> {movie.revenue}</p>
+              <p className='genre'><span className='bold-text'>Genre:</span> {movie.genres}</p>
+              <p className='release-date'><span className='bold-text'>Release Date:</span> {movie.release_date}</p>
+              <p className='budget'><span className='bold-text'>Budget:</span> {movie.budget}</p>
+              <p className='revenue'><span className='bold-text'>Revenue:</span> {movie.revenue}</p>
             </div>
             <p className='movie-overview'>{movie.overview}</p>
           </div>


### PR DESCRIPTION
# What does this PR do?
- finish cypress testing for error handling (all testing is complete for all current functionality)
- create separate error messages for specific errors:
- 500 level, says "We're having some trouble loading the page. Please try again later!" with no link to home page
- 404 (page not found), says "Oh no! Looks like this was a rancid tomatillo." with a link back to the home page
- all other errors, says "Oops! Something went wrong. Please reload the page and try agian." with a link back to the home page
- note: trying to view a movie's details for a movie that does not have a title does not actually return an error, but we are still throwing an error that simulates a 404 response

# Is this a feature / refactor / bug fix?
- feature (testing)
- refactor (error messages)

# How has this been tested?
- running cypress, all tests passing 

# Resources used (if any):


# Next steps:
