### PR TITLE
Post all data as numbers for user rating

### DIFF
--- a/src/components/SingleMovie/SingleMovie.js
+++ b/src/components/SingleMovie/SingleMovie.js
@@ -64,7 +64,7 @@ class SingleMovie extends Component {
 
   setRating = (rating) => {
     api.postRating({
-      user_id: this.state.userId,
+      user_id: parseInt(this.state.userId),
       movie_id: parseInt(this.state.id),
       rating: parseInt(rating)
     })


### PR DESCRIPTION
# What does this PR do?
- update post request so that all data is being posted as an integer

# Is this a feature / refactor / bug fix?
- refactor

# How has this been tested?
- posting new ratings and checking the api, all data appears as numbers now (some where posting as strings before)

# Resources used (if any):


# Next steps:
